### PR TITLE
Code Clean up

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "babel-eslint": "^6.0.4",
     "babel-loader": "6.2.2",
     "babel-plugin-syntax-object-rest-spread": "^6.5.0",
+    "babel-plugin-transform-class-properties": "^6.9.1",
     "babel-plugin-transform-object-rest-spread": "^6.6.5",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "6.5.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   "dependencies": {
     "autoprefixer": "^6.3.6",
     "history": "^2.1.1",
-    "lodash": "^4.12.0",
     "react": "0.14.7",
     "react-dom": "0.14.7",
     "react-ga": "^1.4.1",

--- a/src/components/components/Breadcrumbs.js
+++ b/src/components/components/Breadcrumbs.js
@@ -1,11 +1,10 @@
 import React, { PropTypes } from 'react';
 
 import { Link } from 'react-router';
-import { map } from 'lodash';
 
 const BreadCrumbs = ({ links }) => (
   <span className="breadcrumbs">
-    { map(links, (link, i) => (
+    { links.map((link, i) => (
       <span key={i}>
         <Link to={link.href}>{link.name}</Link>
       </span>

--- a/src/components/views/Entries/Entries.js
+++ b/src/components/views/Entries/Entries.js
@@ -1,12 +1,11 @@
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
-import { map } from 'lodash';
 
 import SingleEntry from './SingleEntry';
 
 let Entries = ({ entries }) => (
   <span>
-    { map(entries, entry =>
+    { entries.map(entry =>
       <SingleEntry title={entry.title} key={`${entry.title}_id`} content={entry.content} />
     )}
   </span>

--- a/src/components/views/Post/PostContainer.js
+++ b/src/components/views/Post/PostContainer.js
@@ -15,14 +15,11 @@ class PostContainerComponent extends Component {
       title: '',
       content: '',
     };
-
-    this.onPublishClick = this.onPublishClick.bind(this);
-    this.onChange = this.onChange.bind(this);
   }
 
   onPublishClick() {
-    const { dispatch } = this.props;
-    dispatch(fetchPostEntry(this.state));
+    const { fetchPost } = this.props;
+    fetchPost(this.state);
   }
 
   onChange(e) {
@@ -32,10 +29,22 @@ class PostContainerComponent extends Component {
   }
 
   render() {
+    const { title, content } = this.state
     return (
-      <Post {...this} {...this.state} />
+      <Post
+        onChange={this.onChange.bind(this)}
+        onPublishClick={this.onPublishClick.bind(this)}
+        title={title}
+        content={content}
+      />
     );
   }
 }
 
-export const PostContainer = connect()(PostContainerComponent);
+export const mapDispatchToProps = (dispatch) => ({
+  fetchPost: (post) => {
+    dispatch(fetchPostEntry(post))
+  }
+})
+
+export const PostContainer = connect(null, mapDispatchToProps)(PostContainerComponent);


### PR DESCRIPTION
hey @keyserfaty !

I've made some changes to my fork since your last update here is the changelog:
- I've added `babel-plugin-transform-class-properties` to the package json, if is not there webpack will fail b/c it's listed on the `babel.rc`
- I've replaced `_.map` w/ the `map` function builted in ES6, and since we don't need `lodash` for now I've removed that dependency out ( see: https://www.sitepoint.com/lodash-features-replace-es6/)
- I've also added the `mapDispatchToProps` function to the `PostContainer.js` since this is one of the best practices to deal w/ `dispatch`'s
- Also I think it's better to pass the props to the `Post` component individually than make them share the scope 

I think that's all, feel free to reach me out for any feedback / modification that you may think could be useful.
